### PR TITLE
Enforce Absolute extrusion `G90`

### DIFF
--- a/site/index.py
+++ b/site/index.py
@@ -149,7 +149,6 @@ def gencode():
     file.write(f"G92 E0\n")
     file.write(f"G1 F200 E1\n")
     file.write(f"G92 E0\n")
-    file.write(f"G90\n")
 
     file.write(f"{sgcode}\n")
 
@@ -161,7 +160,11 @@ def gencode():
     zpos = lh
     epos = 0
     
-
+    #Enforce Absolute extrusion for the bottom layers (layers 1-2)      
+    file.write(f";Enforce Absolute extrusion\n")
+    file.write(f";\n")
+    file.write(f"G90 ; use absolute coordinates\n")
+    file.write(f";\n")
 
     #Start Movement        
     file.write(f";Start Movement\n")


### PR DESCRIPTION
Move the `G90` call out of the start gcode into its own block to prevent people from accidentally replacing the needed G90 call; if they replace the start gcode with custom start gcode.

if the G90 call is missing or a `M83 ; extruder relative mode` is placed after the `G90` call and supercedes the `G90` call, this will cause very undesirable extrusion behavior over extruding tons.

This PR makes the `G90` call more explicit and in its own block to prevent users from inadvertently deleting it. (I've done it a few times before I found out that `M83` will cause lots of problems if the `G90` call is missing)